### PR TITLE
Fix boss music override, Gunslinger ammo swap bug, dormancy sqrt perf

### DIFF
--- a/game.js
+++ b/game.js
@@ -143,14 +143,14 @@ const Music = {
     if (this.ctx) { this.ctx.close(); this.ctx = null; }
   },
   switchToNight() {
-    if (this.mode === 'night') return;
-    if (this.mode !== 'boss') this._preNightMode = null;
+    if (this.mode === 'night' || this.mode === 'boss') return;
+    this._preBossMode = null;
     this.mode = 'night';
     // The current loop will naturally end and _nightLoop will take over
   },
   switchToDay() {
-    if (this.mode === 'day') return;
-    if (this.mode !== 'boss') this._preBossMode = null;
+    if (this.mode === 'day' || this.mode === 'boss') return;
+    this._preBossMode = null;
     this.mode = 'day';
     this._dawnJingle();
   },
@@ -5235,7 +5235,7 @@ class GameScene extends Phaser.Scene {
     player.hp        = Math.max(1, Math.round(newCh.maxHp * hpPct));
     player.spr.setTexture(newCh.id);
     player.lbl.setText(newCh.player);
-    if (newCh.id==='gunslinger') player.ammo = 8;
+    if (newCh.id==='gunslinger') { player.ammo = 8; player.reserveAmmo = 32; }
 
     // Update STATE for consistency
     if (player === this.p1) STATE.p1CharId = newCh.id;
@@ -7625,16 +7625,15 @@ class GameScene extends Phaser.Scene {
       // ── Dormancy: wildlife enemies far from all players sleep (no AI, no physics) ──
       // Raiders are always aggressive — never dormant. Boss already excluded above.
       if (!e.isRaider) {
-        let _minDist = Infinity;
+        let _minDist2 = Infinity;
         for (const p of players) {
           const _dx = e.spr.x - p.spr.x, _dy = e.spr.y - p.spr.y;
-          const _d = Math.sqrt(_dx * _dx + _dy * _dy);
-          if (_d < _minDist) _minDist = _d;
+          const _d2 = _dx * _dx + _dy * _dy;
+          if (_d2 < _minDist2) _minDist2 = _d2;
         }
-        if (!players.length) _minDist = Infinity;
 
         if (e._dormant) {
-          if (_minDist < CFG.WAKE_RADIUS) {
+          if (_minDist2 < CFG.WAKE_RADIUS * CFG.WAKE_RADIUS) {
             // Wake up
             e._dormant = false;
             if (e.spr.body) e.spr.body.enable = true;
@@ -7646,7 +7645,7 @@ class GameScene extends Phaser.Scene {
             return;
           }
         } else {
-          if (_minDist > CFG.DORMANT_RADIUS) {
+          if (_minDist2 > CFG.DORMANT_RADIUS * CFG.DORMANT_RADIUS) {
             // Go dormant
             e._dormant = true;
             e.spr.setVelocity(0, 0);


### PR DESCRIPTION
Fixes 2 confirmed bugs and 1 performance issue found during code review — none of these were tracked in existing issues.\n\n**Bug: Boss music silenced by day/night transitions**\n`switchToNight()` and `switchToDay()` had no guard against `mode === 'boss'`, so a boss fight spanning a day/night boundary would override the music mode. `switchFromBoss()` then returned early (its own guard `if (mode !== 'boss') return`), leaving music stuck in the wrong mode for the rest of the run. Both functions now return early when in boss mode. Also fixed a copy-paste error where `switchToNight()` was clearing `this._preNightMode` — a variable never assigned anywhere.\n\n**Bug: Gunslinger has 0 reserve ammo after Barracks character swap**\n`barrackConfirm()` set `player.ammo = 8` when swapping to Gunslinger but never initialized `player.reserveAmmo`. Knight/Architect characters have `reserveAmmo: 0`, so swapping from either left Gunslinger unable to reload after the first clip. Now initializes `reserveAmmo = 32` alongside the clip.\n\n**Perf: `Math.sqrt` removed from per-frame enemy dormancy check**\nThe dormancy loop called `Math.sqrt` for every wildlife enemy vs. every player, 60× per second. Switched to squared-distance comparison, eliminating the sqrt entirely.