### PR TITLE
fix: initialise this.pois before _buildLakes to prevent iOS crash

### DIFF
--- a/game.js
+++ b/game.js
@@ -4063,6 +4063,9 @@ class GameScene extends Phaser.Scene {
     this._log('buildWorld: _buildPonds start', 'world');
     this._buildPonds(stx, sty);
     this._log(`buildWorld: _buildPonds done  water=${(this.waterTiles||[]).length} ice=${(this.iceTiles||[]).length} deep=${(this.deepWaterTiles||[]).length}`, 'world');
+    // ── POINTS OF INTEREST (initialised early so _buildLakes can push to it) ──
+    this.pois = [];
+
     // Larger lakes (6–8 per map) with water-den spawners
     this._log('buildWorld: _buildLakes start', 'world');
     this._buildLakes(stx, sty);
@@ -4208,7 +4211,7 @@ class GameScene extends Phaser.Scene {
     }
 
     // ── POINTS OF INTEREST ────────────────────────────────────
-    this.pois = [];
+    // (this.pois already initialised above before _buildLakes)
     this._log('buildWorld: buildPOIs start', 'world');
     this.buildPOIs(stx, sty, TILE);
     this._log(`buildWorld: buildPOIs done  pois=${(this.pois||[]).length}`, 'world');
@@ -7693,6 +7696,7 @@ class GameScene extends Phaser.Scene {
   _buildLakes(stx, sty) {
     const { TILE, SAFE_R } = CFG;
     this.waterDens = this.waterDens || [];
+    this.pois = this.pois || [];
     let _lakePlaced = 0, _lakeSkipCenter = 0, _lakeSkipBlob = 0;
     // 7 lakes spread across the map; biome variety makes them feel natural
     const lakeSpecs = ['grass','grass','swamp','swamp','waste','tundra','fungal'];


### PR DESCRIPTION
## Summary

- `_buildLakes()` pushes water-den entries into `this.pois` but the array wasn't created until ~150 lines later in `buildWorld()`, causing `undefined is not an object (evaluating 'this.pois.push')` on first load
- On iOS every session is a fresh first load, so this crashed 100% of the time; desktop repeat runs masked the bug because `this.pois` survived from the previous scene instance
- The duplicate `this.pois = []` that ran *after* `_buildLakes` was also silently wiping all water-den minimap POIs every run

## Changes

- Moved `this.pois = []` to just before `_buildLakes` is called so the array exists when lakes register their water dens
- Removed the now-duplicate initialisation that was inadvertently erasing water-den POIs
- Added `this.pois = this.pois || []` guard inside `_buildLakes` itself, matching the existing pattern used for `this.waterDens`

## Test plan

- [ ] Load game on iOS (iPhone/iPad) — should no longer show the "Load error on run #1" screen
- [ ] Confirm water dens appear as POI dots on the minimap (were previously invisible due to the wipe bug)
- [ ] Verify normal desktop gameplay is unaffected