### PR TITLE
Fix #93: revert PR #92 fire-lighting subsystem (5% world-build hang)

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,7 +7,7 @@
 // ── VERSION ───────────────────────────────────────────────────
 // Update this each commit so the title screen reflects the build date.
 // Stored as UTC ISO so it can be displayed in each player's local timezone.
-const VERSION = '2026-04-19T22:41:37Z';
+const VERSION = '2026-04-22T00:00:00Z';
 // Format VERSION into the viewer's local time with abbreviated tz name (EDT, PDT, BST, etc.)
 function _fmtVersion(iso) {
   try {
@@ -835,8 +835,7 @@ function buildTextures(scene) {
   g.generateTexture('campfire', 16, 14);
 
   // Fire glow — radial warm gradient with softer falloff so it reads as
-  // a real pool of light rather than concentric color rings.  Drawn ADD-blended
-  // above the night overlay by _addFireGlow so it visibly cuts through darkness.
+  // a real pool of light rather than concentric color rings.
   g.clear();
   g.fillStyle(0xff6611, 0.08); g.fillCircle(64, 64, 64);
   g.fillStyle(0xff7722, 0.10); g.fillCircle(64, 64, 56);
@@ -8062,64 +8061,23 @@ class GameScene extends Phaser.Scene {
 
   // Attach a pulsating warm-glow halo to a campfire, campsite, or torch.
   // baseScale controls the radius: 1.6 = campfire/campsite (expanded), 0.45 = torch.
-  //
-  // The glow is drawn above the night overlay (depth 50 > nightOverlay.depth 49)
-  // with ADD blend, so at night it bites a bright pool of light into the darkness.
-  // Three decoupled modulators drive its alpha each frame (see updateFireGlows):
-  //   g._pulse    0.55–0.80   slow sine breathe (the original warmth pulse)
-  //   g._flicker  0.85–1.15   fast random flicker (the restless-flame feel)
-  //   nightFactor 0–1         time-of-day master (fires dim at noon, bloom at night)
   _addFireGlow(x, y, baseScale = 1.6) {
     const glow = this.add.image(x, y, 'fire_glow')
-      .setScale(baseScale).setAlpha(0)   // real alpha recomputed each frame in updateFireGlows
-      .setDepth(50)
+      .setScale(baseScale).setAlpha(0.55).setDepth(3)
       .setBlendMode(Phaser.BlendModes.ADD);
     this._w(glow);
     if (this.hudCam) this.hudCam.ignore(glow);
-    // Initial values for the per-frame modulators (tweens own the state from here on).
-    glow._pulse   = 0.68;
-    glow._flicker = 1.0;
-    // Slow scale breathe (unchanged from original behaviour).
+    // Pulse scale
     this.tweens.add({
       targets: glow, scale: baseScale * 1.35, duration: 1400,
       ease: 'Sine.InOut', yoyo: true, loop: -1,
     });
-    // Slow alpha breathe — now drives _pulse (a custom field), not alpha directly.
+    // Pulse alpha (slightly offset phase for organic feel)
     this.tweens.add({
-      targets: glow, _pulse: 0.80, duration: 1100,
+      targets: glow, alpha: 0.80, duration: 1100,
       ease: 'Sine.InOut', yoyo: true, loop: -1, delay: 200,
     });
-    // Fast flicker — re-rolls duration + target every hop so it doesn't feel rhythmic.
-    const kickFlicker = () => {
-      if (!glow.active) return;
-      this.tweens.add({
-        targets: glow,
-        _flicker: 0.85 + Math.random() * 0.30,
-        duration: Phaser.Math.Between(70, 140),
-        ease: 'Linear',
-        onComplete: kickFlicker,
-      });
-    };
-    kickFlicker();
-    // Register so updateFireGlows can retune alpha each frame by nightFactor.
-    (this._fireGlows = this._fireGlows || []).push(glow);
     return glow;
-  }
-
-  // Re-alpha every registered fire glow based on the current nightFactor
-  // and the two per-glow modulators. Called once per frame from updateDayNight.
-  _updateFireGlows() {
-    const glows = this._fireGlows;
-    if (!glows || glows.length === 0) return;
-    const nf = this.nightFactor || 0;
-    // Daytime floor 0.15 keeps glows barely visible in sunlight; nighttime
-    // multiplier up to 1.0 so they bloom to full brightness at midnight.
-    const master = 0.15 + 0.85 * nf;
-    for (let i = glows.length - 1; i >= 0; i--) {
-      const g = glows[i];
-      if (!g || !g.active) { glows.splice(i, 1); continue; }
-      g.alpha = master * (g._pulse || 0.68) * (g._flicker || 1.0);
-    }
   }
 
   // Spawn a wall-mounted torch sprite + glow at world position (x, y).
@@ -9580,10 +9538,6 @@ class GameScene extends Phaser.Scene {
       this.nightOverlay.fillStyle(0x000033, nightAlpha);
       this.nightOverlay.fillRect(0, 0, worldW, worldH);
     }
-    // Exposed 0–1 time-of-day factor — fire glows read this every frame so
-    // torches and campfires bloom into real pools of light as night deepens.
-    this.nightFactor = Math.min(1, nightAlpha / 0.6);
-    this._updateFireGlows();
 
     // Music transitions + first-night contextual tip
     if (this.isNight && !wasNight) {


### PR DESCRIPTION
Closes #93.

Option **B** from the #93 write-up: surgical revert of the PR #92 fire-lighting subsystem (the #85 work), which is the highest-suspicion cause of the 5% "Seeding biomes…" hang. Leaves the other four tracked changes from PR #92 live — Hardcore differentiation (#84), juice (#87), bug bundle (#86), and Settings pause overlay (#88).

## What changed

**`_addFireGlow` restored to pre-#92 form:**
- Removed the recursive `kickFlicker` self-reproducing tween (the prime suspect — every torch spawned a perpetual stream of 70–140 ms tweens via `onComplete: kickFlicker`).
- Removed the `_pulse` / `_flicker` custom-field modulators.
- Removed the `_fireGlows` registry push.
- Restored `depth: 3`, `alpha: 0.55` (was `depth: 50`, `alpha: 0`).
- Kept the two slow scale + alpha yoyo tweens driving `alpha` directly, as on main pre-#92.

**Removed `_updateFireGlows()` method** entirely — no longer needed without the per-glow modulators.

**`updateDayNight`:** removed the `this.nightFactor = …` computation and the `this._updateFireGlows()` per-frame call.

**Kept intact:** the softer 8-ring `fire_glow` texture (aesthetic, not a perf suspect), ADD blend mode, and all three caller sites (`_addFireGlow(x, y)` / `(x, y, 0.45)`).

## Trade-off

The "fires bloom from noon to midnight" look added in #85 is gone — glows are back to the flat 0.55–0.80 breathe they had before PR #92. If you want that night-bloom feel back, we can rebuild it in a followup once the hang is confirmed fixed, without the tween-saturation pattern.

## Diff scope

```
 game.js | 58 ++++++----------------------------------------------------
 1 file changed, 6 insertions(+), 52 deletions(-)
```

## Test plan

- [ ] Load the game (1P Survival) — confirm the 5% "Seeding biomes…" bar advances past 12% without hanging.
- [ ] Repeat for 1P Hardcore, 2P Survival, 2P Hardcore.
- [ ] Visit a campsite at night — glow should still be visible as a warm pulsing halo (just no fast flicker and no night-bloom).
- [ ] Visit a ruins biome at night — multiple torches render, no FPS drop.
- [ ] Press `` ` `` then **G** to confirm debug log still downloads cleanly.

https://claude.ai/code/session_016wqrhcYxqCuiJvS8xdtYkE