### PR TITLE
Store food in inventory when player is at full HP

### DIFF
--- a/game.js
+++ b/game.js
@@ -10340,10 +10340,17 @@ class GameScene extends Phaser.Scene {
           }
           this.redrawHUD();
         } else if (item.itemType === 'food') {
-          const _foodHeal = Math.max(1, Math.round(15 * this.hc.foodHealMult));
-          player.hp = Math.min(player.maxHp, player.hp + _foodHeal);
-          this._log(`${player.charData.player} picked up food  hp=${player.hp}/${player.maxHp}`, 'player');
-          label = '+' + _foodHeal + ' HP';
+          if (player.hp < player.maxHp) {
+            const _foodHeal = Math.max(1, Math.round(15 * this.hc.foodHealMult));
+            player.hp = Math.min(player.maxHp, player.hp + _foodHeal);
+            this._log(`${player.charData.player} picked up food  hp=${player.hp}/${player.maxHp}`, 'player');
+            label = '+' + _foodHeal + ' HP';
+          } else {
+            player.inv.food = (player.inv.food || 0) + 1;
+            this.resourcesGathered++;
+            this._log(`${player.charData.player} stored food (full HP)  inv=${JSON.stringify(player.inv)}`, 'player');
+            label = '+1 Food';
+          }
         } else {
           player.inv[item.itemType] = (player.inv[item.itemType] || 0) + 1;
           this.resourcesGathered++;
@@ -11644,9 +11651,15 @@ class GameScene extends Phaser.Scene {
           }
           this.redrawHUD();
         } else if (crate.itemType === 'food') {
-          const _crateFoodHeal = Math.max(1, Math.round(20 * this.hc.foodHealMult));
-          player.hp = Math.min(player.maxHp, player.hp + _crateFoodHeal);
-          this._log(`${player.charData.player} crate food +${_crateFoodHeal}  hp=${player.hp}/${player.maxHp}`, 'player');
+          if (player.hp < player.maxHp) {
+            const _crateFoodHeal = Math.max(1, Math.round(20 * this.hc.foodHealMult));
+            player.hp = Math.min(player.maxHp, player.hp + _crateFoodHeal);
+            this._log(`${player.charData.player} crate food +${_crateFoodHeal}  hp=${player.hp}/${player.maxHp}`, 'player');
+          } else {
+            player.inv.food = (player.inv.food || 0) + 2;
+            this.resourcesGathered += 2;
+            this._log(`${player.charData.player} crate food stored (full HP)  inv=${JSON.stringify(player.inv)}`, 'player');
+          }
         } else {
           player.inv[crate.itemType] = (player.inv[crate.itemType] || 0) + 2;
           this.resourcesGathered += 2;


### PR DESCRIPTION
## Summary

- Food was always consumed immediately for HP healing, making the Med Kit (`food:2, fiber:3`) and Flower Bouquet (`food:2, fiber:1`) crafting recipes impossible to complete
- Now, if a player is already at full HP, food is stored in `inv.food` instead (+1 from drops, +2 from crates)
- Wounded players still auto-heal as before; healthy players accumulate food for crafting

## Test plan

- [ ] Pick up food while wounded — should heal 15 HP (drop) / 20 HP (crate) as before
- [ ] Pick up food while at full HP — should show "+1 Food" and increment `inv.food`
- [ ] Craft a Med Kit at a bench with 3 fiber + 2 stored food — should succeed
- [ ] Craft a Flower Bouquet (Lauren) with 1 fiber + 2 stored food — should succeed
- [ ] HUD inventory display shows `Food:N` when food is stored

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyRJ5w6QA6hqTkGMStsAoP)_