### PR TITLE
Bump VERSION to 2026-04-30 after #107 merge

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,7 +7,7 @@
 // ── VERSION ───────────────────────────────────────────────────
 // Update this each commit so the title screen reflects the build date.
 // Stored as UTC ISO so it can be displayed in each player's local timezone.
-const VERSION = '2026-04-24T19:44:27Z';
+const VERSION = '2026-04-30T00:20:17Z';
 // Format VERSION into the viewer's local time with abbreviated tz name (EDT, PDT, BST, etc.)
 function _fmtVersion(iso) {
   try {


### PR DESCRIPTION
Title-screen "Last updated" timestamp was still showing Apr 24 after merging #107. Bumped `VERSION` (`game.js:10`) to current UTC so the title screen and session-log header reflect the actual deploy time.

One-line change. Ready to merge.

https://claude.ai/code/session_01CY7PGt71qfhL6Mk5MGsrvm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY7PGt71qfhL6Mk5MGsrvm)_