### PR TITLE
Enable gh-CLI issue creation + draft the relic-on-mountain & day-4 freeze bug reports

### DIFF
--- a/game.js
+++ b/game.js
@@ -194,7 +194,7 @@
 // ── VERSION ───────────────────────────────────────────────────
 // Update this each commit so the title screen reflects the build date.
 // Stored as UTC ISO so it can be displayed in each player's local timezone.
-const VERSION = '2026-06-05T15:24:44Z';
+const VERSION = '2026-06-05T19:07:38Z';
 // Format VERSION into the viewer's local time with abbreviated tz name (EDT, PDT, BST, etc.)
 function _fmtVersion(iso) {
   try {

--- a/scripts/github-issues/01-relic-unreachable-on-mountain.md
+++ b/scripts/github-issues/01-relic-unreachable-on-mountain.md
@@ -1,0 +1,65 @@
+## Type
+Bug / world-gen
+
+## Problem
+A relic POI can spawn on top of (or inside the collision footprint of) a
+mountain, where the player physically cannot reach it. Because winning requires
+depositing all 5 relics at the altar (`relicsHeld === 5`), a single unreachable
+relic makes the run **permanently unwinnable**.
+
+Observed live: a relic sitting on a mountain ridge with the player unable to
+path to it (screenshot in original report — relic glows on dark mountain
+terrain, "carrying 1 / ALTAR ◇◇◇◇◇").
+
+## Root cause
+Relics are placed in `buildPOIs()` via `findInBiome()`, which rejects tiles
+flagged by `_isImpassable()`:
+- `game.js:6666` — `_isImpassable` checks `_waterMap` and `_solidTileSet`
+- `game.js:6824` — relic placement calls `findInBiome(biome, 80)`
+
+The gap is in `_solidTileSet` coverage. It is built by marking only a **3×3
+tile** neighborhood around each mountain's *anchor* tile:
+- `game.js:6515-6521`
+
+But mountains are rendered at scale up to **4.0×** (`game.js:6480`, `:6508`).
+A `mountain` sprite is 96×80 px; at 4× that is 384×320 px ≈ **12×10 tiles** of
+visual footprint. The marked 3×3 set covers only a fraction of the area a large
+mountain visually/physically occupies.
+
+Result: a relic tile can pass the `_isImpassable` check (not in the 3×3 set,
+not water) yet sit buried in a mountain cluster, ringed by mountain collision
+bodies the player can't cross. There is also **no reachability check** from
+spawn and **no relocation fallback** if the chosen tile ends up boxed in.
+
+Note: each mountain's *physics* body is only a ~13px-radius circle at the
+visual base (`game.js:6445-6457`), so it is the surrounding cluster of these
+circles — plus the visual burial — that strands the relic, not a single body.
+
+## Why this is a hard blocker
+Win condition is `relicsHeld === 5` deposited at the altar (manifest §22;
+`_depositRelic`). One unreachable relic ⇒ can never reach 5 ⇒ run cannot be won.
+
+## Proposed fixes (any/all)
+1. **Expand `_solidTileSet` to the real mountain footprint.** When marking a
+   mountain, mark a radius derived from its display size
+   (`Math.ceil(displayWidth / TILE / 2)`) instead of a fixed ±1, so impassable
+   checks reflect large mountains.
+2. **Reachability validation for relics.** After placement, BFS/flood-fill from
+   spawn over passable tiles; if a relic tile is unreachable, relocate it to the
+   nearest reachable tile in the same biome (mirrors the relocation logic
+   proposed in #109 for underwater POIs).
+3. **Widen `findInBiome` fallback** so it never returns a possibly-blocked tile
+   (`game.js:6681-6687`).
+4. **Runtime safety net:** if a relic is still unreachable in play, allow
+   pickup/channel from an adjacent tile, or auto-return it to a reachable spot.
+
+## Related
+- #109 (POIs placed on unreachable/underwater tiles) — same *class* of bug
+  (unreachable POIs), different root cause (this is solid-tile under-coverage,
+  not water-gen ordering). A shared "relocate POIs off impassable tiles" pass
+  could fix both.
+
+## Repro notes
+- Procedurally generated, so it is intermittent — depends on a relic biome
+  roll landing in a large mountain cluster. The fix should be deterministic
+  (coverage + reachability), not RNG-reroll-only.

--- a/scripts/github-issues/02-freeze-around-day-4.md
+++ b/scripts/github-issues/02-freeze-around-day-4.md
@@ -1,0 +1,48 @@
+## Type
+Bug / stability
+
+## Problem
+The local build froze completely around **day 4**, requiring a reload. A freeze
+at this point is severe: combined with the relic-on-mountain bug, a single run
+can become both frozen and unwinnable.
+
+## Day-4 correlation
+"~Day 4" lines up with the **boss spawn** schedule:
+- Boss first spawns on `hc.bossStartDay` — **Hardcore = day 4**, Survival = day 5
+  (`game.js:13592`)
+- The hunting party also keys off early days via `huntNextDay`
+  (`game.js:13566`), and can overlap the boss window.
+
+The boss code path already carries freeze forensics, which strongly suggests
+this area has stalled before:
+- On a boss roll it sets `this._stageTrace = true` so every `update()` stage
+  logs its entry until the boss spawns (`game.js:13600`)
+- It **auto-downloads the session log ~250 ms before spawn** (`game.js:13607`)
+- There is an existing comment describing a prior **Safari** freeze where a
+  *synchronous* `a.click()` log download stalled the scheduler so the 5 s
+  `spawnBoss` `delayedCall` never fired (`game.js:13602-13606`)
+
+## What we need to confirm root cause
+The forensic log that **auto-downloads around day 4/5** on the frozen run:
+- File: `iron-wasteland-YYYY-MM-DD.txt` (downloads automatically; or press the
+  backtick `` ` `` key then `G`)
+- Look at: final FPS reading, the last `[WORLD ]` entries, and whether the
+  per-stage trace shows which `update()` stage was last entered before the
+  freeze.
+
+Per `CLAUDE.md`, the debug log is the primary tool for freeze/crash reports —
+attaching it here will localize the stall.
+
+## Hypotheses to check (pending log)
+- Boss spawn / telegraph path stalling the update loop — consistent with the
+  forensic instrumentation living exactly here.
+- Synchronous log download (`_downloadLog(true)`) re-introducing the documented
+  scheduler stall on some browsers.
+- A spike in active enemies / particles at the boss + hunting-party overlap
+  around day 4 (`spawnHuntingParty`, `spawnBoss`).
+
+## Please include when reporting
+- Browser + OS (Chrome / Safari / Firefox).
+- Mode: **Survival or Hardcore?** (Hardcore puts the first boss on day 4,
+  matching the freeze timing exactly.)
+- The auto-downloaded `iron-wasteland-*.txt` from the frozen run.

--- a/scripts/github-issues/PROGRESS.md
+++ b/scripts/github-issues/PROGRESS.md
@@ -17,6 +17,11 @@ issues because they use the Mac's authenticated `gh`. Cloud sessions start
 blank, so they can't without setup.)
 
 ## Done
+- **Filed both issues** (the GitHub MCP reconnected mid-session exposing
+  `mcp__github__issue_write`, so creation worked directly — no token/setup
+  needed after all):
+  - #122 — Relic can spawn unreachable on a mountain → unwinnable.
+  - #123 — Game freezes ~day 4 (correlates with boss spawn).
 - Root-caused both bugs (see Findings below).
 - Committed tooling + issue drafts to this branch (PR #120, CI green):
   - `scripts/web-setup.sh` — installs `gh` in cloud sessions; documents `GH_TOKEN`.
@@ -27,20 +32,16 @@ blank, so they can't without setup.)
 - Bumped `VERSION` (required by `version-bump` CI on every PR).
 
 ## Open items / next steps
-- [ ] **File the two issues.** Pick one:
-  - Easiest: run it from a **local-folder desktop session** (Mac `gh` already
-    authed) — just ask Claude there to create the two issues.
-  - Express lane: paste the two `.md` bodies into GitHub's "New issue" form.
-  - Cloud automation (reusable): add `GH_TOKEN` (PAT, `repo` scope) +
-    setup-script `apt-get update -y && apt-get install -y gh` in the
-    environment settings, relaunch, then `bash scripts/github-issues/create-issues.sh`.
-- [ ] **Fix bug #1 (relic-on-mountain)** — well understood, self-contained.
-- [ ] **Fix bug #2 (day-4 freeze)** — needs the auto-downloaded forensic log
-      from a frozen run to confirm root cause before fixing.
+- [x] **File the two issues.** Done → #122, #123 (via `mcp__github__issue_write`).
+- [ ] **Fix bug #1 (relic-on-mountain, #122)** — well understood, self-contained.
+- [ ] **Fix bug #2 (day-4 freeze, #123)** — needs the auto-downloaded forensic
+      log from a frozen run to confirm root cause before fixing.
 - [ ] **Sync to canonical folder.** This cloud work is on a GitHub branch, NOT
       the local iCloud `Iron Wasteland` folder. Merge PR #120 + `git pull`
       locally (per CLAUDE.md's "edits must land in the iCloud folder" rule).
-- [ ] Decide whether to keep PR #120 as tooling-only or also land the bug fixes.
+- [ ] Decide what to do with **PR #120**: the issue drafts/runner are now
+      redundant (issues are filed), but `scripts/web-setup.sh` is still useful
+      if you ever want cloud sessions to use `gh`. Keep, trim, or close.
 
 ## Findings (root-cause detail, for later reference)
 

--- a/scripts/github-issues/PROGRESS.md
+++ b/scripts/github-issues/PROGRESS.md
@@ -1,0 +1,84 @@
+# Progress & Open Items — Iron Wasteland
+
+_Working note. Lives on branch `claude/intelligent-tesla-Dg8U8` / PR #120.
+Last touched: 2026-06-05._
+
+## Context (how we got here)
+A local-folder playtest surfaced two bugs:
+1. The game **froze around day 4**.
+2. A **relic spawned on a mountain**, unreachable — and since winning needs all
+   5 relics deposited at the altar, that run was unwinnable.
+
+Goal was to file these as GitHub issues. Discovered the current session is a
+**Claude Code on the web (cloud)** session, whose built-in GitHub tools are
+**read + comment only** — no issue creation, and `gh`/raw API are sandboxed off.
+(Local desktop sessions pointed at the iCloud `Iron Wasteland` folder can create
+issues because they use the Mac's authenticated `gh`. Cloud sessions start
+blank, so they can't without setup.)
+
+## Done
+- Root-caused both bugs (see Findings below).
+- Committed tooling + issue drafts to this branch (PR #120, CI green):
+  - `scripts/web-setup.sh` — installs `gh` in cloud sessions; documents `GH_TOKEN`.
+  - `scripts/github-issues/01-relic-unreachable-on-mountain.md` — issue body.
+  - `scripts/github-issues/02-freeze-around-day-4.md` — issue body.
+  - `scripts/github-issues/create-issues.sh` — one-shot `gh issue create` runner.
+  - `scripts/github-issues/README.md` — the end-to-end flow.
+- Bumped `VERSION` (required by `version-bump` CI on every PR).
+
+## Open items / next steps
+- [ ] **File the two issues.** Pick one:
+  - Easiest: run it from a **local-folder desktop session** (Mac `gh` already
+    authed) — just ask Claude there to create the two issues.
+  - Express lane: paste the two `.md` bodies into GitHub's "New issue" form.
+  - Cloud automation (reusable): add `GH_TOKEN` (PAT, `repo` scope) +
+    setup-script `apt-get update -y && apt-get install -y gh` in the
+    environment settings, relaunch, then `bash scripts/github-issues/create-issues.sh`.
+- [ ] **Fix bug #1 (relic-on-mountain)** — well understood, self-contained.
+- [ ] **Fix bug #2 (day-4 freeze)** — needs the auto-downloaded forensic log
+      from a frozen run to confirm root cause before fixing.
+- [ ] **Sync to canonical folder.** This cloud work is on a GitHub branch, NOT
+      the local iCloud `Iron Wasteland` folder. Merge PR #120 + `git pull`
+      locally (per CLAUDE.md's "edits must land in the iCloud folder" rule).
+- [ ] Decide whether to keep PR #120 as tooling-only or also land the bug fixes.
+
+## Findings (root-cause detail, for later reference)
+
+### Bug 1 — Relic can spawn unreachable on a mountain (unwinnable)
+- Relics placed in `buildPOIs()` via `findInBiome()`, which rejects tiles
+  flagged by `_isImpassable()` (`game.js:6666`); relic call at `game.js:6824`.
+- `_isImpassable` checks `_waterMap` + `_solidTileSet`. The gap: `_solidTileSet`
+  marks only a **3×3 tile** box around each mountain's anchor tile
+  (`game.js:6515-6521`), while mountains render up to **4×** (`game.js:6480`,
+  `:6508`) — a 96×80 sprite at 4× ≈ **12×10 tiles**. So a relic can pass the
+  check yet land buried in a mountain cluster, ringed by collision bodies.
+- No reachability check from spawn; no relocation fallback.
+- Mountain physics body is only a ~13px circle at the visual base
+  (`game.js:6445-6457`) — it's the *cluster* of these + visual burial that
+  strands the relic.
+- Win condition: `relicsHeld === 5` at altar (manifest §22, `_depositRelic`).
+- **Proposed fix:** size `_solidTileSet` coverage to each mountain's real
+  footprint (`ceil(displayWidth / TILE / 2)`), + a BFS reachability/relocation
+  pass for relics (mirrors the underwater-POI relocation in issue #109).
+- Related: **#109** (POIs on unreachable/underwater tiles) — same class,
+  different root cause (water-gen ordering vs solid-tile under-coverage).
+
+### Bug 2 — Freeze ~day 4 (correlates with boss spawn)
+- "~Day 4" matches **boss spawn**: `hc.bossStartDay` = 4 (Hardcore), 5
+  (Survival) (`game.js:13592`). Hunting party (`huntNextDay`, `game.js:13566`)
+  can overlap.
+- Boss path already carries freeze forensics: sets `_stageTrace = true`
+  (`game.js:13600`) and **auto-downloads the session log ~250ms before spawn**
+  (`game.js:13607`). Existing comment notes a prior Safari freeze from a
+  *synchronous* `a.click()` log download stalling the scheduler
+  (`game.js:13602-13606`).
+- **Need:** the auto-downloaded `iron-wasteland-*.txt` from the frozen run
+  (final FPS, last `[WORLD ]` entries, last `update()` stage in the trace).
+- Hypotheses: boss spawn/telegraph stalling the loop; sync log download
+  re-introducing the documented stall; enemy/particle spike at the
+  boss+hunting-party overlap.
+
+## Key references
+- PR: https://github.com/captjkirk/Iron-Wasteland/pull/120
+- Branch: `claude/intelligent-tesla-Dg8U8`
+- Cloud-session docs: https://code.claude.com/docs/en/claude-code-on-the-web

--- a/scripts/github-issues/README.md
+++ b/scripts/github-issues/README.md
@@ -1,0 +1,20 @@
+# Pending bug issues (Claude Code on the web)
+
+Cloud sessions' built-in GitHub tools are **read + comment only** — they can't
+open new issues. To let an agent file these, install `gh` and provide a token:
+
+1. **Add a token.** In your environment settings, set `GH_TOKEN` to a GitHub
+   PAT (`repo` scope, or fine-grained with `Issues: read/write`).
+2. **Install gh.** Point your environment setup script at `scripts/web-setup.sh`
+   (or paste `apt update && apt install -y gh` into it).
+3. **Relaunch.** Env-var / setup-script changes only apply to a *new* session.
+4. **Create the issues.** Run `bash scripts/github-issues/create-issues.sh`.
+
+## Issue drafts in this folder
+| File | Title |
+|------|-------|
+| `01-relic-unreachable-on-mountain.md` | Relic can spawn unreachable on a mountain → game becomes unwinnable |
+| `02-freeze-around-day-4.md` | Game freezes ~day 4 (correlates with boss spawn) — capture forensic log |
+
+The bodies are reusable: paste them into the GitHub web UI manually if you'd
+rather not wire up `gh`.

--- a/scripts/github-issues/create-issues.sh
+++ b/scripts/github-issues/create-issues.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Creates the two bug issues from the markdown bodies in this directory.
+#
+# Prereqs (see scripts/web-setup.sh):
+#   • gh installed         → bash scripts/web-setup.sh
+#   • GH_TOKEN env var set  → PAT with repo / Issues:read-write scope
+#
+# Idempotency: this is a plain `gh issue create`; running it twice creates
+# duplicates. Check `gh issue list` first if unsure.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${IRON_WASTELAND_REPO:-captjkirk/iron-wasteland}"
+
+echo "Creating issues in $REPO …"
+
+gh issue create --repo "$REPO" \
+  --title "Relic can spawn unreachable on a mountain → game becomes unwinnable" \
+  --label "bug" --label "world-gen" \
+  --body-file "$DIR/01-relic-unreachable-on-mountain.md"
+
+gh issue create --repo "$REPO" \
+  --title "Game freezes ~day 4 (correlates with boss spawn) — capture forensic log" \
+  --label "bug" \
+  --body-file "$DIR/02-freeze-around-day-4.md"
+
+echo "Done. Verify with: gh issue list --repo $REPO"

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Setup script for Claude Code on the web (cloud sessions).
+#
+# The built-in GitHub tools in a cloud session are READ + COMMENT only — they
+# cannot create issues. This script installs the GitHub CLI (`gh`) so an agent
+# (or you) can run `gh issue create`, `gh release`, etc., that the built-in
+# tools don't cover.
+#
+# HOW TO USE
+#   1. In your environment settings, add a GH_TOKEN environment variable.
+#      Use a GitHub Personal Access Token with `repo` scope (classic) or a
+#      fine-grained token with `Issues: read/write`. The container has no
+#      secrets store and the built-in proxy token never enters the container,
+#      so the PAT must arrive as an env var. `gh` reads GH_TOKEN automatically.
+#   2. Point your environment's "setup script" at this file (e.g. run
+#      `bash scripts/web-setup.sh`), or paste the apt line below into it.
+#   3. Start a fresh session — env-var and setup-script changes only take
+#      effect on a NEW session, not a running one.
+#
+# Then: bash scripts/github-issues/create-issues.sh
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+echo "[web-setup] Installing GitHub CLI (gh)…"
+if command -v gh >/dev/null 2>&1; then
+  echo "[web-setup] gh already present: $(gh --version | head -1)"
+else
+  apt-get update -y
+  apt-get install -y gh
+  echo "[web-setup] gh installed: $(gh --version | head -1)"
+fi
+
+if [ -n "${GH_TOKEN:-}" ]; then
+  echo "[web-setup] GH_TOKEN detected — gh is authenticated for this session."
+else
+  echo "[web-setup] WARNING: GH_TOKEN is not set."
+  echo "[web-setup]   Add it in your environment settings (PAT with repo /"
+  echo "[web-setup]   Issues:read-write scope) so gh can create issues."
+fi
+
+echo "[web-setup] Done."


### PR DESCRIPTION
## Why
Two bugs were reported from a local playtest:
1. **Game froze ~day 4.**
2. **A relic spawned on a mountain**, making the run unwinnable (relic can't be reached, and winning needs all 5 deposited at the altar).

The goal was to file these as GitHub issues, but **cloud sessions' built-in GitHub tools are read + comment only** — they can't open issues, and `gh`/raw API are sandboxed off by default. This PR wires up the supported path (`gh` CLI + `GH_TOKEN`) and ships the two issue write-ups so filing them is one command.

## What's here (no game logic changed)
- `scripts/web-setup.sh` — installs the GitHub CLI in a cloud session and documents the required `GH_TOKEN` env var.
- `scripts/github-issues/` — ready-to-file bodies for both bugs + `create-issues.sh` runner + `README.md` explaining the flow.
- `game.js` — **VERSION constant bumped only** (required by the `version-bump` CI check; no other changes).

## How to actually create the issues
1. Add a `GH_TOKEN` env var in environment settings (PAT with `repo` / `Issues:read-write`).
2. Point the environment setup script at `scripts/web-setup.sh` (or paste `apt update && apt install -y gh`).
3. Relaunch the session (env/setup changes only apply to new sessions).
4. Run `bash scripts/github-issues/create-issues.sh`.

The bodies are plain markdown — they can also be pasted into the GitHub web UI directly without any of the above.

## Findings captured in the drafts
- **Relic unreachable:** `_solidTileSet` marks only a 3×3 tile box per mountain (`game.js:6515-6521`) while mountains render up to 4× (~12×10 tiles), so a relic can pass the `_isImpassable` check yet land buried in a mountain cluster with no reachability/relocation fallback. Same *class* as #109, different root cause.
- **Day-4 freeze:** correlates with boss spawn (Hardcore `bossStartDay = 4`); the boss path already auto-downloads a forensic log ~250 ms before spawn (`game.js:13607`) — the draft asks for that log to confirm.

Draft — opening for visibility; the issue bodies are the deliverable.

https://claude.ai/code/session_01P3kdE3SJK49TabaPn694N7

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3kdE3SJK49TabaPn694N7)_